### PR TITLE
add support for 128k clusters

### DIFF
--- a/bcread.c
+++ b/bcread.c
@@ -126,7 +126,7 @@ unsigned long BadClustPreserve32(void) /* should use multisector read here */
           bad_sector_map_pointer--; /* too-many-bad-clusters workaround! */
         }
         bad_sector_map[bad_sector_map_pointer] =
-          cluststart + ((j+i-2) * parameter_block.bpb.sectors_per_cluster);
+          cluststart + ((j+i-2) * BPB_SECTORS_PER_CLUSTER(parameter_block.bpb));
         bad_sector_map_pointer++;
         countbad++;
       }
@@ -145,7 +145,7 @@ unsigned long BadClustPreserve32(void) /* should use multisector read here */
   printf("\n Cluster stats: %lu used, %lu bad, %lu items, %lu last.\n",
     countused, countbad, countitems, last_used);
   return ( cluststart +
-    ( (1+last_used-2) * parameter_block.bpb.sectors_per_cluster ) - 1 );
+    ( (1+last_used-2) * BPB_SECTORS_PER_CLUSTER(parameter_block.bpb) ) - 1 );
     /* we round up to the END of the cluster */
 } /* BadClustPreserve32 */
 
@@ -204,7 +204,7 @@ unsigned long BadClustPreserve16(void)
           bad_sector_map_pointer--; /* too-many-bad-clusters workaround! */
         }
         bad_sector_map[bad_sector_map_pointer] =
-          cluststart + ((j+i-2) * parameter_block.bpb.sectors_per_cluster);
+          cluststart + ((j+i-2) * BPB_SECTORS_PER_CLUSTER(parameter_block.bpb));
         bad_sector_map_pointer++;
         countbad++;
       }
@@ -216,7 +216,7 @@ unsigned long BadClustPreserve16(void)
   printf("\n Cluster stats: %lu used, %lu bad, %lu items, %lu last.\n",
     countused, countbad, countitems, last_used);
   return ( cluststart +
-    ( (1+last_used-2) * parameter_block.bpb.sectors_per_cluster ) - 1 );
+    ( (1+last_used-2) * BPB_SECTORS_PER_CLUSTER(parameter_block.bpb) ) - 1 );
     /* we round up to the END of the cluster */
 } /* BadClustPreserve16 */
 
@@ -270,7 +270,7 @@ unsigned long BadClustPreserve12(void) /* FAT12 is max 12 sectors / FAT, simple 
         bad_sector_map_pointer--; /* too-many-bad-clusters workaround! */
       }
       bad_sector_map[bad_sector_map_pointer] =
-        cluststart + ((clust-2) * parameter_block.bpb.sectors_per_cluster);
+        cluststart + ((clust-2) * BPB_SECTORS_PER_CLUSTER(parameter_block.bpb));
       bad_sector_map_pointer++;
     }
     if (clustb > 0xff0) {
@@ -280,7 +280,7 @@ unsigned long BadClustPreserve12(void) /* FAT12 is max 12 sectors / FAT, simple 
         bad_sector_map_pointer--; /* too-many-bad-clusters workaround! */
       }
       bad_sector_map[bad_sector_map_pointer] =
-        cluststart + ((clust+1-2) * parameter_block.bpb.sectors_per_cluster);
+        cluststart + ((clust+1-2) * BPB_SECTORS_PER_CLUSTER(parameter_block.bpb));
       bad_sector_map_pointer++;
     }
     if (clusta > 0) {
@@ -297,7 +297,7 @@ unsigned long BadClustPreserve12(void) /* FAT12 is max 12 sectors / FAT, simple 
   printf("\n Cluster stats: %lu used, %lu bad, %lu items, %lu last.\n",
     countused, countbad, countitems, last_used);
   return ( cluststart +
-    ( (1+last_used-2) * parameter_block.bpb.sectors_per_cluster ) - 1 );
+    ( (1+last_used-2) * BPB_SECTORS_PER_CLUSTER(parameter_block.bpb) ) - 1 );
     /* we round up to the END of the cluster */
 } /* BadClustPreserve12 */
 

--- a/btstrct.h
+++ b/btstrct.h
@@ -25,6 +25,10 @@ typedef struct Standard_Boot_Sector_Fields
   BT8 oem_id[8];   /* 0x03   3 */
 } STD_BS;
 
+/* Helper macro to support cluster sizes of 256 sectors. This is encoded 
+   as zero in bpb.sectors_per_cluster */
+#define BPB_SECTORS_PER_CLUSTER(bpb)(((bpb).sectors_per_cluster) ? (bpb).sectors_per_cluster : 256)
+
 typedef struct Standard_BPB
 {
   BT16 bytes_per_sector       ;   /* 0x0b   11 */

--- a/createfs.c
+++ b/createfs.c
@@ -278,12 +278,12 @@ void Create_FS_Info_Sector()
 
   fs_info_sector.free_count         = file_sys_info.total_clusters -
     ( file_sys_info.number_root_dir_sect
-      / parameter_block.bpb.sectors_per_cluster ); /* root dir consumes clusters! */
+      / BPB_SECTORS_PER_CLUSTER(parameter_block.bpb) ); /* root dir consumes clusters! */
 
 #if 0 /* more correct but not even MS FORMAT seems to use that value! */
   fs_info_sector.next_free          = 2UL + /* 2 based counting */
     ( file_sys_info.number_root_dir_sect
-      / parameter_block.bpb.sectors_per_cluster ); /* root dir consumes clusters! */
+      / BPB_SECTORS_PER_CLUSTER(parameter_block.bpb) ); /* root dir consumes clusters! */
 #else
   fs_info_sector.next_free          = 2UL;
 #endif
@@ -317,12 +317,7 @@ static unsigned long cluster_count(void)
   if (param.fat_type != FAT32) /* in FAT32, root dir uses normal clusters */
     totalsect -= file_sys_info.number_root_dir_sect;
 
-  if (parameter_block.bpb.sectors_per_cluster==0) {
-    printf("0 sectors/cluster in BPB!? Aborting.\n");
-    Exit(4,20);
-  } /* new 0.91b sanity check */
-
-  return (totalsect / parameter_block.bpb.sectors_per_cluster);
+  return (totalsect / BPB_SECTORS_PER_CLUSTER(parameter_block.bpb));
 }
 
 
@@ -376,7 +371,7 @@ void Get_FS_Info()
       unsigned long rdent = 512; /* default number of root dir entries */
 
       entries_per_cluster = parameter_block.bpb.bytes_per_sector / 32;
-      entries_per_cluster *= parameter_block.bpb.sectors_per_cluster;
+      entries_per_cluster *= BPB_SECTORS_PER_CLUSTER(parameter_block.bpb);
 
       parameter_block.bpb.root_directory_entries = 0; /* must be 0 for FAT32 */
 
@@ -714,7 +709,7 @@ void Write_FAT_Tables()
     /* ADDED CLUSTER CHAIN CREATION - 0.91e, fixed 0.91i+ */
     sbp = 8;
     nclust = file_sys_info.number_root_dir_sect;
-    nclust /= parameter_block.bpb.sectors_per_cluster;
+    nclust /= BPB_SECTORS_PER_CLUSTER(parameter_block.bpb);
     printf(" Optimized initial Root Directory size: %lu clusters.\n",
       nclust);
     cnum = 2; /* first data cluster has number 2, not 0...: 2 based counting */

--- a/floppy.c
+++ b/floppy.c
@@ -996,7 +996,7 @@ skip_int13_18:	/* *** end skipable int 13.18 stuff (jump added 0.91s) *** */
     / parameter_block.bpb.bytes_per_sector;
 
   drive_statistics.sect_in_each_allocation_unit =
-    (unsigned long)parameter_block.bpb.sectors_per_cluster;
+    (unsigned long)BPB_SECTORS_PER_CLUSTER(parameter_block.bpb);
 
   drive_statistics.bad_sectors = 0; /* 0.91c */
   drive_statistics.bytes_per_sector =

--- a/format.mak
+++ b/format.mak
@@ -8,7 +8,7 @@ CFLAGS=-w -0 -ms -fpc -zp1 -q
 # -ms small memory model -zp1 byte-align structures
 LDFLAGS=
 LDLIBS=
-RM=command /c del
+RM=rm -f
 OBJS1=createfs.obj floppy.obj hdisk.obj main.obj savefs.obj bcread.obj prf.obj
 OBJS2=userint.obj driveio.obj getopt.obj init.obj recordbc.obj uformat.obj
 
@@ -24,10 +24,10 @@ format.exe: $(OBJS1) $(OBJS2)
 
 # clean up:
 
-clean:
+clean: .SYMBOLIC
 	$(RM) *.obj
 
-clobber: 
+clobber: .SYMBOLIC
 	$(RM) *.bak
 	$(RM) *.dsk
 	$(RM) *.exe

--- a/format.mak
+++ b/format.mak
@@ -3,7 +3,7 @@
 
 CC=wcc
 CLINK=wcl
-CFLAGS=-w -0 -ms -fpc -zp1
+CFLAGS=-w -0 -ms -fpc -zp1 -q
 # -w warnall -0 8086 compat -fpc floating point library calls (no FPU)
 # -ms small memory model -zp1 byte-align structures
 LDFLAGS=
@@ -19,50 +19,8 @@ all: format.exe
 format.exe: $(OBJS1) $(OBJS2)
 	$(CLINK) $(CFLAGS) $(LDFLAGS) *.obj $(LDLIBS) -fe=format.exe
 
-# compile targets:
-
-# very convenient but not available in Turbo C 2.01 - generic C/OBJ rule:
-# .c.obj:
-#	$(CC) $(CFLAGS) $*.c
-
-createfs.obj:
-	$(CC) $(CFLAGS) createfs.c
-
-floppy.obj:
-	$(CC) $(CFLAGS) floppy.c
-
-hdisk.obj:
-	$(CC) $(CFLAGS) hdisk.c
-
-main.obj:
-	$(CC) $(CFLAGS) main.c
-
-savefs.obj:
-	$(CC) $(CFLAGS) savefs.c
-
-userint.obj:
-	$(CC) $(CFLAGS) userint.c
-
-driveio.obj:
-	$(CC) $(CFLAGS) driveio.c
-
-getopt.obj:
-	$(CC) $(CFLAGS) getopt.c
-
-init.obj:
-	$(CC) $(CFLAGS) init.c
-
-recordbc.obj:
-	$(CC) $(CFLAGS) recordbc.c
-
-uformat.obj:
-	$(CC) $(CFLAGS) uformat.c
-
-bcread.obj:
-	$(CC) $(CFLAGS) bcread.c
-
-prf.obj:
-	$(CC) $(CFLAGS) prf.c
+.c.obj: .AUTODEPEND
+	$(CC) $(CFLAGS) $*.c
 
 # clean up:
 

--- a/recordbc.c
+++ b/recordbc.c
@@ -40,13 +40,6 @@ int Is_Even(unsigned long number)
 
 void Record_Bad_Clusters(void)
 {
-  if (parameter_block.bpb.sectors_per_cluster == 0)
-    {
-    /* Terminate the program... internal error in FORMAT */
-    printf("\nInternal R.B.C. error!\n");
-    Exit(4,31);
-    }
-
   if (param.fat_type==FAT12) Record_Bad_Clusters_FAT12();
   if (param.fat_type==FAT16) Record_Bad_Clusters_FAT16();
   if (param.fat_type==FAT32) Record_Bad_Clusters_FAT32();
@@ -112,8 +105,8 @@ void Record_Bad_Clusters_FAT12(void)
     /* Translate the sector into a cluster number. */
     /* *** is this correct? *** */
     bad_cluster = ( (bad_sector_map[index] - first_data_sector)
-     + parameter_block.bpb.sectors_per_cluster - 1 ) /* round up */
-       / parameter_block.bpb.sectors_per_cluster;
+     + BPB_SECTORS_PER_CLUSTER(parameter_block.bpb) - 1 ) /* round up */
+       / BPB_SECTORS_PER_CLUSTER(parameter_block.bpb);
     bad_cluster += 2; /* 2 based counting */
 
     if (bad_cluster != last_bad_cluster)
@@ -234,8 +227,8 @@ void Record_Bad_Clusters_FAT16(void)
 	/* *** changed in 0.91i - hope it is correct now??? *** */
 	bad_cluster = (
 	   (bad_sector_map[bad_sector_map_index] - first_data_sector)
-	   + parameter_block.bpb.sectors_per_cluster - 1 ) /* round up */
-	 / parameter_block.bpb.sectors_per_cluster;
+	   + BPB_SECTORS_PER_CLUSTER(parameter_block.bpb) - 1 ) /* round up */
+	 / BPB_SECTORS_PER_CLUSTER(parameter_block.bpb);
 	bad_cluster += 2; /* 2 based counting */
 	}
       else
@@ -244,7 +237,7 @@ void Record_Bad_Clusters_FAT16(void)
       if ( (bad_cluster != last_bad_cluster) && (bad_cluster != 100000L) )
 	{
 	drive_statistics.bad_sectors +=
-	  parameter_block.bpb.sectors_per_cluster;
+	  BPB_SECTORS_PER_CLUSTER(parameter_block.bpb);
 
 	last_bad_cluster = bad_cluster;
 	drive_statistics.allocation_units_with_bad_sectors++; /* 0.91c */
@@ -329,8 +322,8 @@ void Record_Bad_Clusters_FAT32(void) /* added actual FAT writing in 0.91j */
     /* *** changed in 0.91i - correct now? *** */
     bad_cluster = (
       ( bad_sector_map[bad_sector_map_index] - first_data_sector )
-      + parameter_block.bpb.sectors_per_cluster - 1 ) /* round up */
-      / parameter_block.bpb.sectors_per_cluster;
+      + BPB_SECTORS_PER_CLUSTER(parameter_block.bpb) - 1 ) /* round up */
+      / BPB_SECTORS_PER_CLUSTER(parameter_block.bpb);
     bad_cluster += 2; /* 2 based counting */
 
     /* no extra rounding needed... 4 bytes per FAT entry. */

--- a/savefs.c
+++ b/savefs.c
@@ -213,7 +213,8 @@ void Save_File_System(int overwrite)
           }
       } /* root directory an FAT and drive size was plausible */
 
-      sectors_per_cluster = BSWord(0x0d) & 0xff; /* only a byte */
+      sectors_per_cluster = BSWord(0x0d) & 0xff;
+      if (!sectors_per_cluster) sectors_per_cluster = 256;
 
       if (fat_type == FAT32)
         {
@@ -267,7 +268,7 @@ void Save_File_System(int overwrite)
   if ((fat_type == param.fat_type) &&
       (reserved_sectors == parameter_block.bpb.reserved_sectors) &&
       (number_of_fats == parameter_block.bpb.number_of_fats) &&
-      (sectors_per_cluster == parameter_block.bpb.sectors_per_cluster) &&
+      (sectors_per_cluster == BPB_SECTORS_PER_CLUSTER(parameter_block.bpb)) &&
       ( (sectors_per_fat & 0xffff) ==
         ( (fat_type == FAT32) ? parameter_block.xbpb.fat_size_low
                               : parameter_block.bpb.sectors_per_fat ) )
@@ -290,9 +291,9 @@ void Save_File_System(int overwrite)
       if (number_of_fats != parameter_block.bpb.number_of_fats)
         printf("Number of FATs differs: FOUND %lu / PLANNED %hu\n",
           number_of_fats, parameter_block.bpb.number_of_fats);
-      if (sectors_per_cluster != parameter_block.bpb.sectors_per_cluster)
+      if (sectors_per_cluster != BPB_SECTORS_PER_CLUSTER(parameter_block.bpb))
         printf("Cluster size differs: FOUND %lu / PLANNED %hu (sectors)\n",
-          sectors_per_cluster, parameter_block.bpb.sectors_per_cluster);
+          sectors_per_cluster, BPB_SECTORS_PER_CLUSTER(parameter_block.bpb));
       scratch = parameter_block.xbpb.fat_size_high;
       scratch <<= 16;
       scratch |= parameter_block.xbpb.fat_size_low;


### PR DESCRIPTION
I made these changes to test 128k cluster support of the Enhanced DR-DOS kernel. This kernel creates default BPBs with 128K cluster size, if the partition is larger than 1 TiB. These partitions could not be formatted with the FDOS format previously.

Maybe this is of interest to be included in the official format repo? Should be reviewed though, because I am not sure I missed something.
